### PR TITLE
correcting the extensions configuration option

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 module.exports =
   configDefaults:
     filters: ''
-    extensions: 'c++'
+    extensions: 'c++,cc,cpp,cu,cuh,h,hpp'
     cpplintExecutablePath: path.join __dirname, '..', 'bin'
 
   activate: ->


### PR DESCRIPTION
According to [google styleguide](http://google-styleguide.googlecode.com/svn/trunk/cpplint/cpplint.py), the option 
```
extensions=extension,extension,...
      The allowed file extensions that cpplint will check

      Examples:
        --extensions=hpp,cpp
```
restricts the file extensions that can be linted. Adding all the options fixes #7.