### PR TITLE
Add --linelength option support

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -2,6 +2,9 @@ path = require 'path'
 
 module.exports =
   config:
+    lineLength:
+      type: 'integer'
+      default: '80'
     filters:
       type: 'string'
       default: ''

--- a/lib/linter-cpplint.coffee
+++ b/lib/linter-cpplint.coffee
@@ -28,6 +28,9 @@ class LinterCpplint extends Linter
     @subscriptions.add atom.config.observe 'linter-cpplint.cpplintExecutablePath', =>
       @executablePath = atom.config.get 'linter-cpplint.cpplintExecutablePath'
 
+    @subscriptions.add atom.config.observe 'linter-cpplint.lineLength', =>
+      @updateCommand()
+
     @subscriptions.add atom.config.observe 'linter-cpplint.filters', =>
       @updateCommand()
 
@@ -35,9 +38,12 @@ class LinterCpplint extends Linter
       @updateCommand()
 
   updateCommand: ->
+    lineLength = atom.config.get 'linter-cpplint.lineLength'
     filters = atom.config.get 'linter-cpplint.filters'
     extensions = atom.config.get 'linter-cpplint.extensions'
     cmd = "cpplint.py"
+    if lineLength
+      cmd = "#{cmd} --linelength=#{lineLength}"
     if filters
       cmd = "#{cmd} --filter=#{filters}"
     if extensions


### PR DESCRIPTION
Hello,

I noticed the missing support for the --linelength option of cpplint. This PR adds a configuration field for that specific option.

Today the line length limit of 80 characters is quite obsolete, most C++ developers agree on the fact that with moderns IDE, an increased line length actually improves code readability.

Thank you in advance for taking that into consideration.