### PR TITLE
Set the CWD to the dir of the file

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -52,7 +52,10 @@ module.exports =
         # File path is the last parameter.
         parameters.push(filePath)
 
-        execOpt = {stream: 'stderr', allowEmptyStderr: true}
+        execOpt =
+          stream: 'stderr'
+          allowEmptyStderr: true
+          cwd: dirname(filePath)
 
         return helpers
             .exec(@cpplintPath, parameters, execOpt).then (result) ->


### PR DESCRIPTION
Specify a CWD for running `cpplint` of the file being linted.