### PR TITLE
Fix defining the package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "atom-linter": "^9.0.0",
     "atom-package-deps": "^4.0.1"
   },
-  "packages-deps": [
+  "package-deps": [
     "linter"
   ]
 }


### PR DESCRIPTION
Fix a typo in `package.json` that was preventing `atom-package-deps` from finding the list of package dependencies.